### PR TITLE
Handle missing user info in ranking lookups

### DIFF
--- a/go_api/controllers/user/user.go
+++ b/go_api/controllers/user/user.go
@@ -1,15 +1,22 @@
 package user
 
 import (
+	"errors"
+
 	"gbl-api/controllers/booth"
 	"gbl-api/controllers/score"
 	"gbl-api/data"
+	"gorm.io/gorm"
 )
 
 func GetNameFromUID(uid string) (string, error) {
 	var user User
 	db := data.GetDatabase()
 	err := db.Where("uid = ?", uid).First(&user).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return uid, nil
+	}
+
 	return user.Name, err
 }
 
@@ -17,16 +24,18 @@ func GetLastBoothFromUID(uid string) (string, error) {
 	var participation score.Participation
 	db := data.GetDatabase()
 	err := db.Where("uid = ?", uid).Last(&participation).Error
-	if err != nil {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil
+	} else if err != nil {
 		return "", err
 	}
 
 	b, err := booth.GetBooth(db, participation.BID)
-	if err != nil {
-		return "", err
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", nil
 	}
 
-	return b.Name, nil
+	return b.Name, err
 }
 
 func checkBoothVisited(b string, bs []string) bool {


### PR DESCRIPTION
## Summary
- return a fallback value instead of failing when a ranking user record is missing in the database
- allow missing participation or booth records to resolve without crashing the ranking endpoint

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cfc00b53fc83269b95545daaf5f643