### PR TITLE
Fix booth creation validations and admin UI error handling

### DIFF
--- a/go_api/controllers/booth/booth.go
+++ b/go_api/controllers/booth/booth.go
@@ -47,6 +47,16 @@ func GetBoothIdByPassword(password string) (string, error) {
 	}
 }
 
+func HasBoothPasswordByBID(bid string) (bool, error) {
+	db := data.GetDatabase()
+	var count int64
+	if err := db.Model(&BoothPassword{}).Where("bid = ?", bid).Count(&count).Error; err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
 func DeleteBooth(bid string) error {
 	db := data.GetDatabase()
 	return db.Delete(&Booth{}, "bid = ?", bid).Error

--- a/go_api/server/booth.go
+++ b/go_api/server/booth.go
@@ -1,28 +1,81 @@
 package server
 
 import (
+	"errors"
 	"log"
+	"strings"
+	"time"
 
 	"gbl-api/controllers/booth"
 	"gbl-api/migrations"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
+type makeBoothRequest struct {
+	BID          string `json:"bid" binding:"required"`
+	Name         string `json:"name" binding:"required"`
+	Description  string `json:"description" binding:"required"`
+	Part         string `json:"part" binding:"required"`
+	VideoURL     string `json:"video_url" binding:"required"`
+	ThumbnailURL string `json:"thumbnail_url" binding:"required"`
+	PosterURL    string `json:"poster_url" binding:"required"`
+	TimeSlot     string `json:"time_slot" binding:"required"`
+}
+
 func makeBooth(c *gin.Context) {
-	var b booth.Booth
-	err := c.BindJSON(&b)
-	if err != nil {
+	var req makeBoothRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(400, gin.H{
 			"message": "Invalid request",
 		})
 		return
 	}
 
-	err = booth.MakeBooth(b)
+	db := c.MustGet("db").(*gorm.DB)
+
+	hasPassword, err := booth.HasBoothPasswordByBID(req.BID)
 	if err != nil {
+		log.Println(err)
+		c.JSON(500, gin.H{
+			"message": "Internal server error",
+		})
+		return
+	}
+
+	if !hasPassword {
+		c.JSON(404, gin.H{
+			"message": "Booth password not found",
+		})
+		return
+	}
+
+	if _, err := booth.GetBooth(db, req.BID); err == nil {
+		c.JSON(409, gin.H{
+			"message": "Booth already exists",
+		})
+		return
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.Println(err)
+		c.JSON(500, gin.H{
+			"message": "Internal server error",
+		})
+		return
+	}
+
+	newBooth := booth.Booth{
+		BID:          req.BID,
+		Name:         req.Name,
+		Description:  req.Description,
+		Part:         req.Part,
+		VideoURL:     req.VideoURL,
+		ThumbnailURL: req.ThumbnailURL,
+		PosterURL:    req.PosterURL,
+		TimeSlot:     strings.ToUpper(req.TimeSlot),
+	}
+
+	if err := booth.MakeBooth(newBooth); err != nil {
 		log.Println(err)
 		c.JSON(500, gin.H{
 			"message": "Internal server error",
@@ -236,9 +289,9 @@ func addBoothScore(c *gin.Context) {
 	}
 	// 점수 지급 이력 저장
 	db.Create(&migrations.BoothScoreHistory{
-		UID: req.UID,
-		BID: req.BID,
-		Score: req.Score,
+		UID:       req.UID,
+		BID:       req.BID,
+		Score:     req.Score,
 		CreatedAt: time.Now(),
 	})
 	c.JSON(200, gin.H{"success": true})

--- a/ts_fe/src/pages/admin/makebooth/index.tsx
+++ b/ts_fe/src/pages/admin/makebooth/index.tsx
@@ -249,19 +249,27 @@ const MakeBoothPage = () => {
 		});
 	};
 
-	const ErrHandlering = (err: any) => {
-		console.log(err);
-		SetSnackbarInfo({
-			...SnackbarInfo,
-			open: true,
-			text: `오류가 발생했습니다. ${err.response.data.error}`,
-			severity: "warning",
-		});
-		Setloading({
-			...loading,
-			is_loading: false,
-		});
-	};
+        const ErrHandlering = (err: any) => {
+                console.log(err);
+                const message =
+                        err?.response?.data?.message ||
+                        err?.response?.data?.error ||
+                        err?.message ||
+                        "오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
+                SetSnackbarInfo((prev) => ({
+                        ...prev,
+                        open: true,
+                        text: message,
+                        severity: "error",
+                }));
+
+                Setloading((prev) => ({
+                        ...prev,
+                        is_loading: false,
+                        msg: "",
+                }));
+        };
 
 	const onSubmit = () => {
 		Setloading({
@@ -299,31 +307,41 @@ const MakeBoothPage = () => {
 
 		// 썸네일 파일 업로드
 		const ThumbnailformData = new FormData();
-		if (fileList.thumbnail) {
-			ThumbnailformData.append("file", fileList.thumbnail);
-		} else {
-			SetSnackbarInfo({
-				...SnackbarInfo,
-				open: true,
-				text: "썸네일 이미지를 선택해주세요.",
-				severity: "warning"
-			});
-			return;
-		}
+                if (fileList.thumbnail) {
+                        ThumbnailformData.append("file", fileList.thumbnail);
+                } else {
+                        SetSnackbarInfo({
+                                ...SnackbarInfo,
+                                open: true,
+                                text: "썸네일 이미지를 선택해주세요.",
+                                severity: "warning"
+                        });
+                        Setloading((prev) => ({
+                                ...prev,
+                                is_loading: false,
+                                msg: "",
+                        }));
+                        return;
+                }
 
 		// 포스터 파일 업로드
 		const projectposterformData = new FormData();
-		if (fileList.poster) {
-			projectposterformData.append("file", fileList.poster);
-		} else {
-			SetSnackbarInfo({
-				...SnackbarInfo,
-				open: true,
-				text: "프로젝트 이미지를 선택해주세요.",
-				severity: "warning"
-			});
-			return;
-		}
+                if (fileList.poster) {
+                        projectposterformData.append("file", fileList.poster);
+                } else {
+                        SetSnackbarInfo({
+                                ...SnackbarInfo,
+                                open: true,
+                                text: "프로젝트 이미지를 선택해주세요.",
+                                severity: "warning"
+                        });
+                        Setloading((prev) => ({
+                                ...prev,
+                                is_loading: false,
+                                msg: "",
+                        }));
+                        return;
+                }
 
 		// 썸네일 업로드 → 포스터 업로드 → 부스 생성
 		fileUpload(ThumbnailformData, (percent: number) => {
@@ -344,12 +362,12 @@ const MakeBoothPage = () => {
 						msg: `부스를 만드는중입니다.`,
 						is_loading: true,
 					});
-					makeBooth({
-						bid: AdminAuthState.bid,
-						name: formData.boothName,
-						description: formData.boothDescription, 
-						video_url: formData.video_url,
-						thumbnail_url: res_thumbnail.data.file,
+                                        makeBooth({
+                                                bid: AdminAuthState.bid,
+                                                name: formData.boothName,
+                                                description: formData.boothDescription,
+                                                video_url: formData.video_url,
+                                                thumbnail_url: res_thumbnail.data.file,
 						poster_url: res_poster.data.file, // 추가!
 						part: formData.boothField,
 						boothName: formData.boothName,
@@ -357,23 +375,25 @@ const MakeBoothPage = () => {
 						boothField: formData.boothField,
 						peopleNumber: formData.peopleNumber,
 						youtubeLink: formData.video_url,
-						time_slot: formData.time_slot.toUpperCase()
-					}).then((res) => {
-						dispatch(create());
-						SetSnackbarInfo({
-							open: true,
-							text: "부스가 성공적으로 생성되었습니다.",
-							severity: "success"
-						});
-						Setloading({
-							is_loading: false,
-							msg: ""
-						});
-					});
-				})
-				.catch((err) => {
-					ErrHandlering(err);
-				});
+                                                time_slot: formData.time_slot.toUpperCase()
+                                        })
+                                                .then((res) => {
+                                                        dispatch(create());
+                                                        SetSnackbarInfo({
+                                                                open: true,
+                                                                text: "부스가 성공적으로 생성되었습니다.",
+                                                                severity: "success"
+                                                        });
+                                                        Setloading({
+                                                                is_loading: false,
+                                                                msg: ""
+                                                        });
+                                                })
+                                                .catch(ErrHandlering);
+                                })
+                                .catch((err) => {
+                                        ErrHandlering(err);
+                                });
 			})
 			.catch((err) => {
 				ErrHandlering(err);


### PR DESCRIPTION
## Summary
- add a helper to confirm booth passwords exist by BID before creating booths
- harden the makeBooth API handler with validation, duplicate checks, and time slot normalization
- improve the admin booth creation form’s error handling and loading state resets so failures surface properly

## Testing
- npm run lint
- go test ./config

------
https://chatgpt.com/codex/tasks/task_e_68d4fab6a28c832687156ae2211811bb